### PR TITLE
Fix 'register' spelling for processor topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ IDE補完・型安全・設計思想に沿ったメソッド名に統一され�
 | `pub_close_all_subwindows()`              | サブウィンドウをすべて閉じる                        | Container / Processor |
 | `pub_update_state(path, value)`           | 任意パスの状態を型安全に更新                        | Processor / Container |
 | `pub_add_to_list(path, item)`             | リスト要素を型安全に追加                          | Processor / Container |
-| `pub_registor_processor(cls, name)`       | Processor を動的に登録                      | Processor             |
+| `pub_register_processor(cls, name)`       | Processor を動的に登録                      | Processor             |
 | `pub_delete_processor(name)`              | Processor を削除                         | Processor             |
 | `sub_state_changed(path, handler)`        | 指定パスの値変更を購読                           | Container             |
 | `sub_state_added(path, handler)`          | リストへの要素追加を購読                          | Container             |

--- a/docs/REFERENCE_FULL.md
+++ b/docs/REFERENCE_FULL.md
@@ -350,7 +350,7 @@ class PubSubDefaultTopicBase(PubSubBase):
             DefaultUpdateTopic.ADD_TO_LIST, state_path=str(state_path), item=item
         )
 
-    def pub_registor_processor(
+    def pub_register_processor(
         self,
         proc: Type[ProcessorBase],
         name: Optional[str] = None,
@@ -365,7 +365,7 @@ class PubSubDefaultTopicBase(PubSubBase):
         Note:
             登録されたProcessorは、アプリケーションのライフサイクルを通じて有効です。
         """
-        self.publish(DefaultProcessorTopic.REGISTOR_PROCESSOR, proc=proc, name=name)
+        self.publish(DefaultProcessorTopic.REGISTER_PROCESSOR, proc=proc, name=name)
 
     def pub_delete_processor(self, name: str) -> None:
         """指定した名前のProcessorを削除するPubSubメッセージを送信する。
@@ -472,7 +472,7 @@ class DefaultProcessorTopic(AutoNamedTopic):
     標準的なプロセッサ管理のPubSubトピック列挙型。
     """
 
-    REGISTOR_PROCESSOR = auto()
+    REGISTER_PROCESSOR = auto()
     DELETE_PROCESSOR = auto()
 ```
 
@@ -784,7 +784,7 @@ class ApplicationCommon(PubSubDefaultTopicBase, Generic[TState]):
             DefaultNavigateTopic.CLOSE_ALL_SUBWINDOWS, self.close_all_subwindows
         )
         self.subscribe(
-            DefaultProcessorTopic.REGISTOR_PROCESSOR, self.register_processor
+            DefaultProcessorTopic.REGISTER_PROCESSOR, self.register_processor
         )
         self.subscribe(DefaultProcessorTopic.DELETE_PROCESSOR, self.delete_processor)
 
@@ -1431,7 +1431,7 @@ class TodoApp(pubsubtk.TkApplication):
         
     def setup_custom_logic(self):
         # Register processors for business logic
-        self.pub_registor_processor(TodoProcessor)
+        self.pub_register_processor(TodoProcessor)
         
         # Switch to main container
         self.pub_switch_container(MainContainer)

--- a/docs/REFERENCE_SHORT.md
+++ b/docs/REFERENCE_SHORT.md
@@ -237,7 +237,7 @@ class AppState(BaseModel):
 ### 2. アプリケーションセットアップパターン
 
 * `TkApplication` または `ThemedApplication` を継承し、初期ウィンドウ設定と PubSub の Mixin を組み合わせる。
-* 起動時に `pub_registor_processor()` で必要な Processor を登録し、`pub_switch_container()` で最初の Container を表示。
+* 起動時に `pub_register_processor()` で必要な Processor を登録し、`pub_switch_container()` で最初の Container を表示。
 
 ```python
 class MyApp(pubsubtk.TkApplication[AppState]):
@@ -245,7 +245,7 @@ class MyApp(pubsubtk.TkApplication[AppState]):
         super().__init__(AppState, title="My App", geometry="600x400")
 
     def setup_custom_logic(self):
-        self.pub_registor_processor(MyProcessor)
+        self.pub_register_processor(MyProcessor)
         self.pub_switch_container(MainContainer)
 ```
 

--- a/src/pubsubtk/app/application_base.py
+++ b/src/pubsubtk/app/application_base.py
@@ -62,7 +62,7 @@ class ApplicationCommon(PubSubDefaultTopicBase, Generic[TState]):
             DefaultNavigateTopic.CLOSE_ALL_SUBWINDOWS, self.close_all_subwindows
         )
         self.subscribe(
-            DefaultProcessorTopic.REGISTOR_PROCESSOR, self.register_processor
+            DefaultProcessorTopic.REGISTER_PROCESSOR, self.register_processor
         )
         self.subscribe(DefaultProcessorTopic.DELETE_PROCESSOR, self.delete_processor)
 

--- a/src/pubsubtk/core/default_topic_base.py
+++ b/src/pubsubtk/core/default_topic_base.py
@@ -135,7 +135,7 @@ class PubSubDefaultTopicBase(PubSubBase):
             DefaultUpdateTopic.ADD_TO_LIST, state_path=str(state_path), item=item
         )
 
-    def pub_registor_processor(
+    def pub_register_processor(
         self,
         proc: Type[ProcessorBase],
         name: Optional[str] = None,
@@ -150,7 +150,7 @@ class PubSubDefaultTopicBase(PubSubBase):
         Note:
             登録されたProcessorは、アプリケーションのライフサイクルを通じて有効です。
         """
-        self.publish(DefaultProcessorTopic.REGISTOR_PROCESSOR, proc=proc, name=name)
+        self.publish(DefaultProcessorTopic.REGISTER_PROCESSOR, proc=proc, name=name)
 
     def pub_delete_processor(self, name: str) -> None:
         """指定した名前のProcessorを削除するPubSubメッセージを送信する。

--- a/src/pubsubtk/topic/topics.py
+++ b/src/pubsubtk/topic/topics.py
@@ -51,5 +51,5 @@ class DefaultProcessorTopic(AutoNamedTopic):
     標準的なプロセッサ管理のPubSubトピック列挙型。
     """
 
-    REGISTOR_PROCESSOR = auto()
+    REGISTER_PROCESSOR = auto()
     DELETE_PROCESSOR = auto()


### PR DESCRIPTION
## Summary
- rename DefaultProcessorTopic enum constant to REGISTER_PROCESSOR
- rename `pub_registor_processor` method to `pub_register_processor`
- update ApplicationCommon to subscribe using REGISTER_PROCESSOR
- replace `registor` with `register` in docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684191fa7c70833083d94a639ea89539