### PR TITLE
Implement add_to_dict in Store and refactor

### DIFF
--- a/docs/REFERENCE_SHORT.md
+++ b/docs/REFERENCE_SHORT.md
@@ -88,10 +88,12 @@ from tkinter import ttk
 | `pub_close_all_subwindows()`              | サブウィンドウをすべて閉じる                        | Container / Processor |
 | `pub_update_state(path, value)`           | 任意パスの状態を型安全に更新                        | Processor / Container |
 | `pub_add_to_list(path, item)`             | リスト要素を型安全に追加                          | Processor / Container |
+| `pub_add_to_dict(path, key, value)`       | 辞書要素を型安全に追加                | Processor / Container |
 | `pub_registor_processor(cls, name)`       | Processor を動的に登録                      | Processor             |
 | `pub_delete_processor(name)`              | Processor を削除                         | Processor             |
 | `sub_state_changed(path, handler)`        | 指定パスの値変更を購読                           | Container             |
 | `sub_state_added(path, handler)`          | リストへの要素追加を購読                          | Container             |
+| `sub_dict_item_added(path, handler)`      | 辞書への要素追加を購読                | Container             |
 | `register_handler(event, cb)`             | PresentationalコンポーネントでViewイベントのハンドラ登録 | Container             |
 | `trigger_event(event, **kwargs)`          | View→Containerへ任意イベント送出               | Presentational        |
 
@@ -140,6 +142,10 @@ class TodoContainer(ContainerComponentTk[AppState]):
     def add_todo(self):
         # 状態更新
         self.pub_add_to_list(self.store.state.todos, new_todo)
+
+    def add_setting(self, key, val):
+        # 辞書への要素追加
+        self.pub_add_to_dict(self.store.state.settings, key, val)
 ```
 
 **Presentational** - 純粋な表示、再利用可能な部品

--- a/src/pubsubtk/core/default_topic_base.py
+++ b/src/pubsubtk/core/default_topic_base.py
@@ -1,6 +1,10 @@
 # default_topic_base.py - デフォルトトピック操作をまとめた基底クラス
 
-"""主要な PubSub トピックに対する便利メソッドを提供します。"""
+"""
+src/pubsubtk/core/default_topic_base.py
+
+主要な PubSub トピックに対する便利メソッドを提供します。
+"""
 
 from __future__ import annotations
 
@@ -139,6 +143,25 @@ class PubSubDefaultTopicBase(PubSubBase):
             DefaultUpdateTopic.ADD_TO_LIST, state_path=str(state_path), item=item
         )
 
+    def pub_add_to_dict(self, state_path: str, key: str, value: Any) -> None:
+        """Storeの状態(辞書)に要素を追加するPubSubメッセージを送信する。
+
+        Args:
+            state_path: 要素を追加する辞書の状態パス。
+            key: 追加するキー。
+            value: 追加する値。
+
+        Note:
+            **RECOMMENDED**: Use store.state proxy for type-safe paths with IDE support:
+            `self.pub_add_to_dict(str(self.store.state.mapping), "k", v)`
+        """
+        self.publish(
+            DefaultUpdateTopic.ADD_TO_DICT,
+            state_path=str(state_path),
+            key=key,
+            value=value,
+        )
+
     def pub_register_processor(
         self,
         proc: Type[ProcessorBase],
@@ -201,3 +224,23 @@ class PubSubDefaultTopicBase(PubSubBase):
             `self.sub_state_added(str(self.store.state.items), self.on_item_added)`
         """
         self.subscribe(f"{DefaultUpdateTopic.STATE_ADDED}.{str(state_path)}", handler)
+
+    def sub_dict_item_added(
+        self, state_path: str, handler: Callable[[str, Any], None]
+    ) -> None:
+        """辞書に要素が追加されたときの通知を購読する。
+
+        ハンドラー関数には、キーと値が渡されます。
+
+        Args:
+            state_path: 監視する辞書状態のパス。
+            handler: 追加されたキーと値を引数に取る関数。
+
+        Note:
+            **RECOMMENDED**: Use store.state proxy for consistent path specification:
+            `self.sub_dict_item_added(str(self.store.state.mapping), self.on_added)`
+        """
+        self.subscribe(
+            f"{DefaultUpdateTopic.DICT_ADDED}.{str(state_path)}",
+            handler,
+        )

--- a/src/pubsubtk/topic/topics.py
+++ b/src/pubsubtk/topic/topics.py
@@ -1,6 +1,10 @@
 # topics.py - PubSub トピック列挙型の定義
 
-"""アプリケーションで使用する PubSub トピック列挙型を提供します。"""
+"""
+src/pubsubtk/topic/topics.py
+
+アプリケーションで使用する PubSub トピック列挙型を提供します。
+"""
 
 from enum import StrEnum, auto
 
@@ -46,8 +50,10 @@ class DefaultUpdateTopic(AutoNamedTopic):
 
     UPDATE_STATE = auto()
     ADD_TO_LIST = auto()
+    ADD_TO_DICT = auto()
     STATE_CHANGED = auto()
     STATE_ADDED = auto()
+    DICT_ADDED = auto()
 
 
 class DefaultProcessorTopic(AutoNamedTopic):


### PR DESCRIPTION
## Summary
- remove unused `create_partial_state_updater`
- add `add_to_dict` support
- publish dictionary add events via new topics
- expose convenience methods to publish/subscribe dictionary additions
- document new feature
- add `sub_dict_item_added` reference in docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68465ca6488883309aa878ce50a87176