### PR TITLE
Document default win_id usage

### DIFF
--- a/docs/REFERENCE_FULL.md
+++ b/docs/REFERENCE_FULL.md
@@ -152,11 +152,17 @@ self.pub_update_state(f"todos.{index}", updated_todo)
 class TodoContainer(ContainerComponentTk[AppState]):
     def setup_subscriptions(self):
         self.sub_state_changed(self.store.state.todos, self.on_todos_changed)
-    
+
     def add_todo(self):
         # 状態更新
         self.pub_add_to_list(self.store.state.todos, new_todo)
 ```
+
+**備考:** コンポーネントの ``__init__`` では与えられた ``*args`` と ``**kwargs`` が
+``self.args`` / ``self.kwargs`` として保持されます。サブウィンドウを ``open_subwindow``
+で開く場合は ``win_id`` が ``self.kwargs`` に自動追加され、
+``pub_close_subwindow(self.kwargs["win_id"])`` で自身を閉じられます。今後も同様の
+デフォルト引数が追加される可能性があります。
 
 **Presentational** - 純粋な表示、再利用可能な部品
 
@@ -1487,9 +1493,11 @@ class ThemedApplication(ApplicationCommon, ThemedTk):
 #### `src/pubsubtk/ui/base/container_base.py`
 
 ```python
-# container_base.py - コンテナコンポーネントの基底クラス
+"""
+src/pubsubtk/ui/base/container_base.py
 
-"""状態連携可能な UI コンテナの基底クラスを定義します。"""
+状態連携可能な UI コンテナの基底クラスを定義します。
+"""
 
 import tkinter as tk
 from abc import ABC, abstractmethod
@@ -1521,6 +1529,13 @@ class ContainerMixin(PubSubDefaultTopicBase, ABC, Generic[TState]):
 
         Args:
             store: 使用する ``Store`` インスタンス。
+
+        Notes:
+            渡された ``*args`` と ``**kwargs`` は ``self.args`` / ``self.kwargs``
+            として保持されます。サブウィンドウを ``open_subwindow`` で開く場合は
+            ``win_id`` が ``self.kwargs`` に自動追加され、
+            ``pub_close_subwindow(self.kwargs["win_id"])`` として自身を閉じることが
+            できます。将来的に同様のデフォルト引数が増えるかもしれません。
         """
         self.args = args
         self.kwargs = kwargs
@@ -1595,9 +1610,11 @@ class ContainerComponentTtk(ContainerMixin[TState], ttk.Frame, Generic[TState]):
 #### `src/pubsubtk/ui/base/presentational_base.py`
 
 ```python
-# presentational_base.py - 表示専用コンポーネントの基底クラス
+"""
+src/pubsubtk/ui/base/presentational_base.py
 
-"""イベント発火機能を備えた表示専用 UI コンポーネント用基底クラス。"""
+イベント発火機能を備えた表示専用 UI コンポーネント用基底クラス。
+"""
 
 import tkinter as tk
 from abc import ABC, abstractmethod
@@ -1613,7 +1630,14 @@ class PresentationalMixin(ABC):
     """
 
     def __init__(self, *args, **kwargs):
-        """Mixin の初期化処理。"""
+        """Mixin の初期化処理。
+
+        Notes:
+            渡された ``*args`` と ``**kwargs`` は ``self.args`` / ``self.kwargs``
+            として保持されます。サブウィンドウで使用する場合は ``open_subwindow``
+            が ``win_id`` を自動付与するため、 ``self.kwargs["win_id"]`` を利用して
+            自身を閉じられます。今後同様のデフォルト引数が追加される可能性があります。
+        """
 
         self.args = args
         self.kwargs = kwargs

--- a/docs/REFERENCE_SHORT.md
+++ b/docs/REFERENCE_SHORT.md
@@ -136,11 +136,17 @@ self.pub_update_state(f"todos.{index}", updated_todo)
 class TodoContainer(ContainerComponentTk[AppState]):
     def setup_subscriptions(self):
         self.sub_state_changed(self.store.state.todos, self.on_todos_changed)
-    
+
     def add_todo(self):
         # 状態更新
         self.pub_add_to_list(self.store.state.todos, new_todo)
 ```
+
+**備考:** コンポーネントの ``__init__`` では与えられた ``*args`` と ``**kwargs`` が
+``self.args`` / ``self.kwargs`` として保持されます。サブウィンドウを ``open_subwindow``
+で開く場合は ``win_id`` が ``self.kwargs`` に自動追加され、
+``pub_close_subwindow(self.kwargs["win_id"])`` で自身を閉じられます。今後も同様の
+デフォルト引数が追加される可能性があります。
 
 **Presentational** - 純粋な表示、再利用可能な部品
 

--- a/src/pubsubtk/ui/base/container_base.py
+++ b/src/pubsubtk/ui/base/container_base.py
@@ -1,6 +1,8 @@
-# container_base.py - コンテナコンポーネントの基底クラス
+"""
+src/pubsubtk/ui/base/container_base.py
 
-"""状態連携可能な UI コンテナの基底クラスを定義します。"""
+状態連携可能な UI コンテナの基底クラスを定義します。
+"""
 
 import tkinter as tk
 from abc import ABC, abstractmethod
@@ -32,6 +34,13 @@ class ContainerMixin(PubSubDefaultTopicBase, ABC, Generic[TState]):
 
         Args:
             store: 使用する ``Store`` インスタンス。
+
+        Notes:
+            渡された ``*args`` と ``**kwargs`` は ``self.args`` / ``self.kwargs``
+            として保持されます。サブウィンドウを ``open_subwindow`` で開く場合は
+            ``win_id`` が ``self.kwargs`` に自動追加され、
+            ``pub_close_subwindow(self.kwargs["win_id"])`` として自身を閉じることが
+            できます。将来的に同様のデフォルト引数が増えるかもしれません。
         """
         self.args = args
         self.kwargs = kwargs

--- a/src/pubsubtk/ui/base/presentational_base.py
+++ b/src/pubsubtk/ui/base/presentational_base.py
@@ -1,6 +1,8 @@
-# presentational_base.py - 表示専用コンポーネントの基底クラス
+"""
+src/pubsubtk/ui/base/presentational_base.py
 
-"""イベント発火機能を備えた表示専用 UI コンポーネント用基底クラス。"""
+イベント発火機能を備えた表示専用 UI コンポーネント用基底クラス。
+"""
 
 import tkinter as tk
 from abc import ABC, abstractmethod
@@ -16,7 +18,14 @@ class PresentationalMixin(ABC):
     """
 
     def __init__(self, *args, **kwargs):
-        """Mixin の初期化処理。"""
+        """Mixin の初期化処理。
+
+        Notes:
+            渡された ``*args`` と ``**kwargs`` は ``self.args`` / ``self.kwargs``
+            として保持されます。サブウィンドウで使用する場合は ``open_subwindow``
+            が ``win_id`` を自動付与するため、 ``self.kwargs["win_id"]`` を利用して
+            自身を閉じられます。今後同様のデフォルト引数が追加される可能性があります。
+        """
 
         self.args = args
         self.kwargs = kwargs


### PR DESCRIPTION
## Summary
- document `win_id` auto addition to self.kwargs
- keep full and short references aligned with updated comments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68474fe8e38c83308fa5bb3c294c1ad1