### PR TITLE
Undo/redo機能の追加

### DIFF
--- a/scripts/make_pr_summary.bat
+++ b/scripts/make_pr_summary.bat
@@ -1,16 +1,26 @@
 @echo off
 chcp 65001
-REM Get the current branch name
+
+REM 現在のブランチ名を取得
 FOR /F "delims=" %%b IN ('git rev-parse --abbrev-ref HEAD') DO set "feature_branch=%%b"
 
-REM Output commit list to pr_summary.txt
+REM --- 出力開始 -----------------------------------------------------------
 echo == Commit List == > pr_summary.txt
 git log --oneline main..%feature_branch% >> pr_summary.txt
 
-REM Output changed files list
 echo. >> pr_summary.txt
 echo == Changed Files == >> pr_summary.txt
 git diff --name-only main..%feature_branch% >> pr_summary.txt
 
-REM Optional: show a message
+REM 追加：行数ベースのサマリ
+echo. >> pr_summary.txt
+echo == Diff Summary (added / removed lines) == >> pr_summary.txt
+git diff --stat --no-color main..%feature_branch% >> pr_summary.txt
+
+REM 追加：実際の+/-行を含む詳細パッチ
+echo. >> pr_summary.txt
+echo == Detailed Diff == >> pr_summary.txt
+git diff --no-color main..%feature_branch% >> pr_summary.txt
+REM  ↑行数が多くなる場合は --unified=0 で前後コンテキストを省略可能
+
 echo pr_summary.txt has been created for branch %feature_branch%

--- a/src/pubsubtk/core/default_topic_base.py
+++ b/src/pubsubtk/core/default_topic_base.py
@@ -269,62 +269,63 @@ class PubSubDefaultTopicBase(PubSubBase):
     def sub_undo_status(
         self, state_path: str, handler: Callable[[bool, bool, int, int], None]
     ) -> None:
-        """指定したstate pathのUndo/Redo状態変化を購読する。
+        """
+        指定した state path の Undo/Redo 状態変化を購読する。
+
+        ハンドラー関数は以下の引数で呼び出されます：
+            - can_undo (bool): Undo 実行可能かどうか
+            - can_redo (bool): Redo 実行可能かどうか
+            - undo_count (int): 実行可能な Undo 回数
+            - redo_count (int): 実行可能な Redo 回数
 
         Args:
             state_path (str): 監視する状態パス
-            handler (Callable[[bool, bool, int, int], None]): 状態変化時に呼び出される関数。
-                can_undo, can_redo, undo_count, redo_countの4引数を取る
+            handler (Callable[[bool, bool, int, int], None]): 状態変化時に呼び出される関数
 
         Note:
-            **RECOMMENDED**: Use store.state proxy for consistent path specification:
-            `self.sub_undo_status(str(self.store.state.counter), self.on_undo_status_changed)`
-
-            ハンドラー関数は以下の引数で呼び出されます：
-            - can_undo (bool): Undo実行可能かどうか
-            - can_redo (bool): Redo実行可能かどうか
-            - undo_count (int): 実行可能なUndo回数
-            - redo_count (int): 実行可能なRedo回数
+            推奨: store.state プロキシを利用すると IDE 補完や一貫したパス指定が可能です。
+            例: `self.sub_undo_status(self.store.state.counter, self.on_undo_status_changed)`
         """
+
         self.subscribe(f"{DefaultUndoTopic.STATUS_CHANGED}.{str(state_path)}", handler)
 
     def sub_state_changed(
         self, state_path: str, handler: Callable[[Any, Any], None]
     ) -> None:
         """
-        状態が変更されたときの詳細通知を購読する。
+        状態が変更されたときの通知を購読する。
 
-        ハンドラー関数には、old_valueとnew_valueが渡されます。
+        ハンドラー関数は以下の引数で呼び出されます：
+            - old_value (Any): 変更前の値
+            - new_value (Any): 変更後の値
 
         Args:
             state_path (str): 監視する状態のパス（例: "user.name", "items[2].value"）
-            handler (Callable[[Any, Any], None]): 変更時に呼び出される関数。
-                old_valueとnew_valueの2引数を取る
+            handler (Callable[[Any, Any], None]): 変更時に呼び出される関数
 
         Note:
-            **RECOMMENDED**: Use store.state proxy for consistent path specification:
-            `self.sub_state_changed(str(self.store.state.user.name), self.on_name_changed)`
+            推奨: store.state プロキシを利用して一貫したパス指定が可能です。
+            例: `self.sub_state_changed(self.store.state.user.name, self.on_name_changed)`
         """
+
         self.subscribe(f"{DefaultUpdateTopic.STATE_CHANGED}.{str(state_path)}", handler)
 
     def sub_for_refresh(self, state_path: str, handler: Callable[[], None]) -> None:
         """
-        状態が更新されたときにUI再描画用のシンプルな通知を購読する。
+        状態が更新されたときのシンプルな通知（UI再描画用）を購読する。
 
-        ハンドラー関数は引数なしで呼び出され、ハンドラー内で必要に応じて
-        store.get_current_state()を使用して現在の状態を取得できます。
+        ハンドラー関数は以下の引数で呼び出されます：
+            - なし
 
         Args:
-            state_path (str): 監視する状態のパス（例: "user.name", "items[2].value"）
+            state_path (str): 監視する状態のパス
             handler (Callable[[], None]): 更新時に呼び出される引数なしの関数
 
         Note:
-            **RECOMMENDED**: Use store.state proxy for consistent path specification:
-            `self.sub_for_refresh(str(self.store.state.user.name), self.refresh_ui)`
-
-            このメソッドは、変更内容に関係なく「状態が変わったからUI更新」という
-            パターンに最適です。refresh_from_state()と同じロジックを使い回せます。
+            推奨: store.state プロキシを利用して一貫したパス指定が可能です。
+            例: `self.sub_for_refresh(self.store.state.user.name, self.refresh_ui)`
         """
+
         self.subscribe(f"{DefaultUpdateTopic.STATE_UPDATED}.{str(state_path)}", handler)
 
     def sub_state_added(
@@ -333,34 +334,40 @@ class PubSubDefaultTopicBase(PubSubBase):
         """
         リストに要素が追加されたときの通知を購読する。
 
-        ハンドラー関数には、itemとindexが渡されます。
+        ハンドラー関数は以下の引数で呼び出されます：
+            - item (Any): 追加されたアイテム
+            - index (int): 追加されたインデックス
 
         Args:
-            state_path (str): 監視するリスト状態のパス（例: "items", "user.tasks"）
-            handler (Callable[[Any, int], None]): 要素追加時に呼び出される関数。
-                追加されたアイテムとそのインデックスを引数に取る
+            state_path (str): 監視するリスト状態のパス
+            handler (Callable[[Any, int], None]): 要素追加時に呼び出される関数
 
         Note:
-            **RECOMMENDED**: Use store.state proxy for consistent path specification:
-            `self.sub_state_added(str(self.store.state.items), self.on_item_added)`
+            推奨: store.state プロキシを利用して一貫したパス指定が可能です。
+            例: `self.sub_state_added(self.store.state.items, self.on_item_added)`
         """
+
         self.subscribe(f"{DefaultUpdateTopic.STATE_ADDED}.{str(state_path)}", handler)
 
     def sub_dict_item_added(
         self, state_path: str, handler: Callable[[str, Any], None]
     ) -> None:
-        """辞書に要素が追加されたときの通知を購読する。
+        """
+        辞書に要素が追加されたときの通知を購読する。
 
-        ハンドラー関数には、キーと値が渡されます。
+        ハンドラー関数は以下の引数で呼び出されます：
+            - key (str): 追加されたキー
+            - value (Any): 追加された値
 
         Args:
-            state_path: 監視する辞書状態のパス。
-            handler: 追加されたキーと値を引数に取る関数。
+            state_path (str): 監視する辞書状態のパス
+            handler (Callable[[str, Any], None]): 追加されたキーと値を引数に取る関数
 
         Note:
-            **RECOMMENDED**: Use store.state proxy for consistent path specification:
-            `self.sub_dict_item_added(str(self.store.state.mapping), self.on_added)`
+            推奨: store.state プロキシを利用して一貫したパス指定が可能です。
+            例: `self.sub_dict_item_added(self.store.state.mapping, self.on_added)`
         """
+
         self.subscribe(
             f"{DefaultUpdateTopic.DICT_ADDED}.{str(state_path)}",
             handler,

--- a/src/pubsubtk/core/default_topic_base.py
+++ b/src/pubsubtk/core/default_topic_base.py
@@ -1,353 +1,362 @@
-# default_topic_base.py - デフォルトトピック操作をまとめた基底クラス
+# store.py - アプリケーション状態を管理するクラス
 
 """
-src/pubsubtk/core/default_topic_base.py
+src/pubsubtk/store/store.py
 
-主要な PubSub トピックに対する便利メソッドを提供します。
+Pydantic モデルを用いた型安全な状態管理を提供します。
 """
 
-from __future__ import annotations
+import copy
+from collections import defaultdict
+from typing import Any, Generic, Optional, Type, TypeVar, cast
 
-from typing import TYPE_CHECKING, Any, Callable, Optional, Type
+from pydantic import BaseModel
 
 from pubsubtk.core.pubsub_base import PubSubBase
-from pubsubtk.topic.topics import (
-    DefaultNavigateTopic,
-    DefaultProcessorTopic,
-    DefaultUndoTopic,
-    DefaultUpdateTopic,
-)
+from pubsubtk.topic.topics import DefaultUndoTopic, DefaultUpdateTopic
 
-if TYPE_CHECKING:
-    # 型チェック時（mypy や IDE 補完時）のみ読み込む
-    from pubsubtk.processor.processor_base import ProcessorBase
-    from pubsubtk.ui.types import ComponentType, ContainerComponentType
+TState = TypeVar("TState", bound=BaseModel)
 
 
-class PubSubDefaultTopicBase(PubSubBase):
+class StateProxy(Generic[TState]):
     """
-    Built-in convenience methods for common PubSub operations.
+    Storeのstate属性に対する動的なパスアクセスを提供するプロキシ。
 
-    **IMPORTANT**: Container and Processor components should use these built-in methods
-    instead of manually publishing to DefaultTopics. These methods are designed for
-    ease of use and provide better IDE support.
+    - store.state.foo.bar のようなドット記法でネスト属性へアクセス可能
+    - 存在しない属性アクセス時は AttributeError を送出
+    - __repr__ でパス文字列を返す
     """
 
-    def pub_switch_container(
-        self,
-        cls: ContainerComponentType,
-        kwargs: dict = None,
-    ) -> None:
-        """コンテナを切り替えるPubSubメッセージを送信する。
+    def __init__(self, store: "Store[TState]", path: str = ""):
+        """StateProxy を初期化する。
 
         Args:
-            cls (ContainerComponentType): 切り替え先のコンテナコンポーネントクラス
-            kwargs: コンテナに渡すキーワード引数用辞書
-
-        Note:
-            コンテナは、TkApplicationまたはTtkApplicationのコンストラクタで指定された
-            親ウィジェットの子として配置されます。
+            store: 値を参照する対象 ``Store``。
+            path: 現在のパス文字列。
         """
-        self.publish(DefaultNavigateTopic.SWITCH_CONTAINER, cls=cls, kwargs=kwargs)
+        self._store = store
+        self._path = path
 
-    def pub_switch_slot(
-        self,
-        slot_name: str,
-        cls: ComponentType,
-        kwargs: dict = None,
-    ) -> None:
-        """テンプレートの特定スロットのコンテンツを切り替える。
+    def __getattr__(self, name: str) -> "StateProxy[TState]":
+        """属性アクセスを連結した ``StateProxy`` を返す。"""
+        new_path = f"{self._path}.{name}" if self._path else name
+
+        # 存在チェック：TState モデルに new_path が通るか確認
+        cur = self._store.get_current_state()
+        for seg in new_path.split("."):
+            if hasattr(cur, seg):
+                cur = getattr(cur, seg)
+            else:
+                raise AttributeError(f"No such property: store.state.{new_path}")
+
+        return StateProxy(self._store, new_path)
+
+    def __repr__(self) -> str:
+        """パス文字列を返す。"""
+        return f"{self._path}"
+
+    __str__ = __repr__
+
+
+class Store(PubSubBase, Generic[TState]):
+    """
+    型安全な状態管理を提供するジェネリックなStoreクラス。
+
+    - Pydanticモデルを状態として保持し、状態操作を提供
+    - get_current_state()で状態のディープコピーを取得
+    - update_state()/add_to_list()/add_to_dict()で状態を更新し、PubSubで通知
+    - Undo/Redo 機能を提供
+    """
+
+    def __init__(self, initial_state_class: Type[TState]):
+        """Store を初期化する。
 
         Args:
-            slot_name (str): スロット名
-            cls (ComponentType): コンテナまたはプレゼンテーショナルコンポーネントクラス
-            kwargs: コンポーネントに渡すキーワード引数用辞書
-
-        Note:
-            ContainerComponentとPresentationalComponentの両方に対応。
-            テンプレートが設定されていない場合はエラーになります。
+            initial_state_class: 管理対象となる ``BaseModel`` のサブクラス。
         """
-        self.publish(
-            DefaultNavigateTopic.SWITCH_SLOT,
-            slot_name=slot_name,
-            cls=cls,
-            kwargs=kwargs,
-        )
+        self._state_class = initial_state_class
+        self._state = initial_state_class()
 
-    def pub_open_subwindow(
-        self,
-        cls: ComponentType,
-        win_id: Optional[str] = None,
-        kwargs: dict = None,
-    ) -> None:
-        """サブウィンドウを開くPubSubメッセージを送信する。
+        # Undo/Redo 履歴管理用フィールド
+        self._undo_enabled: set[str] = set()  # 追跡対象パス
+        self._undo_stacks: dict[str, list] = defaultdict(list)  # パス別Undoスタック
+        self._redo_stacks: dict[str, list] = defaultdict(list)  # パス別Redoスタック
+        self._max_histories: dict[str, int] = {}  # パス別履歴上限
+        self._during_ur_op: bool = False  # Undo/Redo操作中の再帰抑制フラグ
 
-        Args:
-            cls (ComponentType): サブウィンドウに表示するコンポーネントクラス
-            win_id (Optional[str], optional): サブウィンドウのID。
-                指定しない場合は自動生成される。
-                同じIDを指定すると、既存のウィンドウが再利用される。
-            kwargs: コンポーネントに渡すキーワード引数用辞書
+        # PubSubBase.__init__()を呼び出して購読設定を有効化
+        super().__init__()
 
-        Note:
-            サブウィンドウは、Toplevel ウィジェットとして作成されます。
+    def setup_subscriptions(self):
+        # 既存の状態更新系トピック
+        self.subscribe(DefaultUpdateTopic.UPDATE_STATE, self.update_state)
+        self.subscribe(DefaultUpdateTopic.REPLACE_STATE, self.replace_state)
+        self.subscribe(DefaultUpdateTopic.ADD_TO_LIST, self.add_to_list)
+        self.subscribe(DefaultUpdateTopic.ADD_TO_DICT, self.add_to_dict)
+
+        # Undo/Redo系トピック
+        self.subscribe(DefaultUndoTopic.ENABLE_UNDO_REDO, self._enable_undo_redo)
+        self.subscribe(DefaultUndoTopic.DISABLE_UNDO_REDO, self._disable_undo_redo)
+        self.subscribe(DefaultUndoTopic.UNDO, self._undo)
+        self.subscribe(DefaultUndoTopic.REDO, self._redo)
+
+    @property
+    def state(self) -> TState:
         """
-        self.publish(
-            DefaultNavigateTopic.OPEN_SUBWINDOW, cls=cls, win_id=win_id, kwargs=kwargs
-        )
-
-    def pub_close_subwindow(self, win_id: str) -> None:
-        """サブウィンドウを閉じるPubSubメッセージを送信する。
-
-        Args:
-            win_id (str): 閉じるサブウィンドウのID
+        状態への動的パスアクセス用プロキシを返す。
         """
-        self.publish(DefaultNavigateTopic.CLOSE_SUBWINDOW, win_id=win_id)
+        return cast(TState, StateProxy(self))
 
-    def pub_close_all_subwindows(self) -> None:
-        """すべてのサブウィンドウを閉じるPubSubメッセージを送信する。"""
-        self.publish(DefaultNavigateTopic.CLOSE_ALL_SUBWINDOWS)
+    def get_current_state(self) -> TState:
+        """
+        現在の状態のディープコピーを返す。
+        """
+        return self._state.model_copy(deep=True)
 
-    def pub_replace_state(self, new_state: Any) -> None:
-        """状態オブジェクト全体を置き換えるPubSubメッセージを送信する。
+    def replace_state(self, new_state: TState) -> None:
+        """状態オブジェクト全体を置き換え、全フィールドに変更通知を送信する。
 
         Args:
             new_state: 新しい状態オブジェクト。
         """
-        self.publish(DefaultUpdateTopic.REPLACE_STATE, new_state=new_state)
+        if not isinstance(new_state, self._state_class):
+            raise TypeError(f"new_state must be an instance of {self._state_class}")
 
-    def pub_update_state(self, state_path: str, new_value: Any) -> None:
-        """
-        Storeの状態を更新するPubSubメッセージを送信する。
+        old_state = self._state
+        self._state = new_state.model_copy(deep=True)
+
+        # 全フィールドに変更通知を送信
+        for field_name in self._state_class.model_fields.keys():
+            old_value = getattr(old_state, field_name)
+            new_value = getattr(self._state, field_name)
+
+            self.publish(
+                f"{DefaultUpdateTopic.STATE_CHANGED}.{field_name}",
+                old_value=old_value,
+                new_value=new_value,
+            )
+            self.publish(f"{DefaultUpdateTopic.STATE_UPDATED}.{field_name}")
+
+    def update_state(self, state_path: str, new_value: Any) -> None:
+        """指定パスの属性を更新し、変更通知を送信する。
 
         Args:
-            state_path (str): 更新する状態のパス（例: "user.name", "items[2].value"）
-            new_value (Any): 新しい値
-
-        Note:
-            **RECOMMENDED**: Use store.state proxy for type-safe paths with IDE support:
-            `self.pub_update_state(str(self.store.state.user.name), "新しい名前")`
-            The state proxy provides autocomplete and "Go to Definition" functionality.
+            state_path: 変更対象の属性パス（例: ``"foo.bar"``）。
+            new_value: 新しく設定する値。
         """
+        target_obj, attr_name, old_value = self._resolve_path(str(state_path))
+
+        # Undo履歴をキャプチャ
+        self._capture_for_undo(str(state_path), old_value)
+
+        # 型チェック後に設定
+        self._validate_and_set_value(target_obj, attr_name, new_value)
+
+        # 詳細な変更通知（old_value, new_valueを含む）
         self.publish(
-            DefaultUpdateTopic.UPDATE_STATE,
-            state_path=str(state_path),
+            f"{DefaultUpdateTopic.STATE_CHANGED}.{state_path}",
+            old_value=old_value,
             new_value=new_value,
         )
+        # シンプルな更新通知
+        self.publish(f"{DefaultUpdateTopic.STATE_UPDATED}.{state_path}")
 
-    def pub_add_to_list(self, state_path: str, item: Any) -> None:
-        """
-        Storeの状態（リスト）に要素を追加するPubSubメッセージを送信する。
+    def add_to_list(self, state_path: str, item: Any) -> None:
+        """リスト属性に要素を追加し、追加通知を送信する。"""
+        target_obj, attr_name, current_list = self._resolve_path(str(state_path))
+        if not isinstance(current_list, list):
+            raise TypeError(f"Property at '{state_path}' is not a list")
 
-        Args:
-            state_path (str): 要素を追加するリストの状態パス（例: "items", "user.tasks"）
-            item (Any): 追加する要素
+        # Undo履歴をキャプチャ
+        self._capture_for_undo(str(state_path), current_list)
 
-        Note:
-            **RECOMMENDED**: Use store.state proxy for type-safe paths with IDE support:
-            `self.pub_add_to_list(str(self.store.state.items), new_item)`
-            The state proxy provides autocomplete and "Go to Definition" functionality.
-        """
+        new_list = current_list.copy()
+        new_list.append(item)
+        self._validate_and_set_value(target_obj, attr_name, new_list)
+
+        index = len(new_list) - 1
         self.publish(
-            DefaultUpdateTopic.ADD_TO_LIST, state_path=str(state_path), item=item
+            f"{DefaultUpdateTopic.STATE_ADDED}.{state_path}",
+            item=item,
+            index=index,
         )
+        self.publish(f"{DefaultUpdateTopic.STATE_UPDATED}.{state_path}")
 
-    def pub_add_to_dict(self, state_path: str, key: str, value: Any) -> None:
-        """Storeの状態(辞書)に要素を追加するPubSubメッセージを送信する。
+    def add_to_dict(self, state_path: str, key: str, value: Any) -> None:
+        """辞書属性に要素を追加し、追加通知を送信する。"""
+        target_obj, attr_name, current_dict = self._resolve_path(str(state_path))
+        if not isinstance(current_dict, dict):
+            raise TypeError(f"Property at '{state_path}' is not a dict")
 
-        Args:
-            state_path: 要素を追加する辞書の状態パス。
-            key: 追加するキー。
-            value: 追加する値。
+        # Undo履歴をキャプチャ
+        self._capture_for_undo(str(state_path), current_dict)
 
-        Note:
-            **RECOMMENDED**: Use store.state proxy for type-safe paths with IDE support:
-            `self.pub_add_to_dict(str(self.store.state.mapping), "k", v)`
-        """
+        new_dict = current_dict.copy()
+        new_dict[key] = value
+        self._validate_and_set_value(target_obj, attr_name, new_dict)
+
         self.publish(
-            DefaultUpdateTopic.ADD_TO_DICT,
-            state_path=str(state_path),
+            f"{DefaultUpdateTopic.DICT_ADDED}.{state_path}",
             key=key,
             value=value,
         )
+        self.publish(f"{DefaultUpdateTopic.STATE_UPDATED}.{state_path}")
 
-    def pub_register_processor(
-        self,
-        proc: Type[ProcessorBase],
-        name: Optional[str] = None,
-    ) -> None:
-        """Processorを登録するPubSubメッセージを送信する。
+    # --- Undo/Redo 履歴管理機能 ---
 
-        Args:
-            proc (Type[ProcessorBase]): 登録するProcessorクラス
-            name (Optional[str], optional): Processorの名前。
-                省略した場合はクラス名が使用される。Defaults to None.
+    def _enable_undo_redo(self, state_path: str, max_history: int = 10) -> None:
+        """Undo/Redoを有効化し、初回スナップショットとして現在値を記録。"""
+        self._undo_enabled.add(state_path)
+        self._max_histories[state_path] = max_history
 
-        Note:
-            登録されたProcessorは、アプリケーションのライフサイクルを通じて有効です。
-        """
-        self.publish(DefaultProcessorTopic.REGISTER_PROCESSOR, proc=proc, name=name)
+        try:
+            _, _, current_value = self._resolve_path(state_path)
+            self._undo_stacks[state_path] = [copy.deepcopy(current_value)]
+        except (AttributeError, ValueError):
+            self._undo_stacks[state_path] = []
+        self._redo_stacks[state_path].clear()
 
-    def pub_delete_processor(self, name: str) -> None:
-        """指定した名前のProcessorを削除するPubSubメッセージを送信する。
+        # UI用ステータス通知
+        self._emit_ur_status(state_path)
 
-        Args:
-            name (str): 削除するProcessorの名前
-        """
-        self.publish(DefaultProcessorTopic.DELETE_PROCESSOR, name=name)
+    def _disable_undo_redo(self, state_path: str) -> None:
+        """Undo/Redoを無効化し、履歴を破棄。"""
+        self._undo_enabled.discard(state_path)
+        self._undo_stacks.pop(state_path, None)
+        self._redo_stacks.pop(state_path, None)
+        self._max_histories.pop(state_path, None)
 
-    # --- Undo/Redo ---------------------------------------------------------
+        # UI用ステータス通知
+        self._emit_ur_status(state_path)
 
-    def pub_enable_undo_redo(
-        self, state_path: str, max_history: int = 10
-    ) -> None:
-        """指定したstate pathに対してUndo/Redo機能を有効化するPubSubメッセージを送信する。
+    def _capture_for_undo(self, state_path: str, old_value: Any) -> None:
+        """状態変更前に履歴を記録し、Redo履歴をクリア。"""
+        if state_path not in self._undo_enabled or self._during_ur_op:
+            return
 
-        Args:
-            state_path (str): Undo/Redo対象の状態パス（例: "counter", "user.name"）
-            max_history (int, optional): 保持する履歴の最大数。デフォルトは10。
-                メモリ使用量を制御したい場合に調整してください。
+        stack = self._undo_stacks[state_path]
+        stack.append(copy.deepcopy(old_value))
 
-        Note:
-            **RECOMMENDED**: Use store.state proxy for type-safe paths with IDE support:
-            `self.pub_enable_undo_redo(str(self.store.state.counter), max_history=50)`
-            The state proxy provides autocomplete and "Go to Definition" functionality.
+        max_len = self._max_histories.get(state_path, 10)
+        if len(stack) > max_len:
+            stack.pop(0)
 
-            このメソッドを呼び出すと、指定されたパスの現在の値が初期スナップショットとして
-            履歴に記録され、以降の変更が追跡されます。
-        """
+        self._redo_stacks[state_path].clear()
+
+        # UI用ステータス通知
+        self._emit_ur_status(state_path)
+
+    def _undo(self, state_path: str) -> None:
+        """1つ前の値に戻す。"""
+        if state_path not in self._undo_enabled:
+            return
+        undo_stack = self._undo_stacks[state_path]
+        if len(undo_stack) < 2:
+            return
+
+        try:
+            _, _, current_value = self._resolve_path(state_path)
+            self._redo_stacks[state_path].append(copy.deepcopy(current_value))
+        except (AttributeError, ValueError):
+            return
+
+        self._during_ur_op = True
+        try:
+            undo_stack.pop()
+            prev = undo_stack[-1]
+            self.update_state(state_path, prev)
+        finally:
+            self._during_ur_op = False
+
+        # UI用ステータス通知
+        self._emit_ur_status(state_path)
+
+    def _redo(self, state_path: str) -> None:
+        """Redo履歴を適用する。"""
+        if state_path not in self._undo_enabled:
+            return
+        redo_stack = self._redo_stacks[state_path]
+        if not redo_stack:
+            return
+
+        try:
+            _, _, current_value = self._resolve_path(state_path)
+            self._undo_stacks[state_path].append(copy.deepcopy(current_value))
+        except (AttributeError, ValueError):
+            return
+
+        self._during_ur_op = True
+        try:
+            next_val = redo_stack.pop()
+            self.update_state(state_path, next_val)
+        finally:
+            self._during_ur_op = False
+
+        # UI用ステータス通知
+        self._emit_ur_status(state_path)
+
+    def _emit_ur_status(self, state_path: str) -> None:
+        """現在のUndo/Redo可否・スタックサイズを通知する."""
+        undo_stack = self._undo_stacks.get(state_path, [])
+        redo_stack = self._redo_stacks.get(state_path, [])
         self.publish(
-            DefaultUndoTopic.ENABLE_UNDO_REDO,
-            state_path=str(state_path),
-            max_history=max_history,
+            f"{DefaultUndoTopic.STATUS_CHANGED}.{state_path}",
+            can_undo=len(undo_stack) > 1,
+            can_redo=len(redo_stack) > 0,
+            undo_count=max(len(undo_stack) - 1, 0),
+            redo_count=len(redo_stack),
         )
 
-    def pub_disable_undo_redo(self, state_path: str) -> None:
-        """指定したstate pathのUndo/Redo機能を無効化するPubSubメッセージを送信する。
-
-        Args:
-            state_path (str): 無効化する状態パス
-
-        Note:
-            **RECOMMENDED**: Use store.state proxy for type-safe paths with IDE support:
-            `self.pub_disable_undo_redo(str(self.store.state.counter))`
-
-            このメソッドを呼び出すと、指定されたパスの履歴データが完全に削除され、
-            メモリが解放されます。再度有効化したい場合はpub_enable_undo_redoを
-            呼び出してください。
+    def _resolve_path(self, path: str) -> tuple[Any, str, Any]:
         """
-        self.publish(DefaultUndoTopic.DISABLE_UNDO_REDO, state_path=str(state_path))
-
-    def pub_undo(self, state_path: str) -> None:
-        """指定したstate pathの状態を1つ前の値に戻すPubSubメッセージを送信する。
-
-        Args:
-            state_path (str): Undoを実行する状態パス
-
-        Note:
-            **RECOMMENDED**: Use store.state proxy for type-safe paths with IDE support:
-            `self.pub_undo(str(self.store.state.counter))`
-
-            履歴が存在しない場合や、既に最初の状態の場合は何も実行されません。
-            Undoされた変更はRedoで元に戻すことができます。
+        属性パスを解決し、対象オブジェクト・属性名・現在値を返す。
         """
-        self.publish(DefaultUndoTopic.UNDO, state_path=str(state_path))
+        segments = path.split(".")
+        if not segments:
+            raise ValueError("Empty path")
 
-    def pub_redo(self, state_path: str) -> None:
-        """指定したstate pathのUndoを取り消すPubSubメッセージを送信する。
+        attr_name = segments[-1]
+        current = self._state
+        for segment in segments[:-1]:
+            if not hasattr(current, segment):
+                raise AttributeError(f"No such attribute: {segment} in path {path}")
+            current = getattr(current, segment)
 
-        Args:
-            state_path (str): Redoを実行する状態パス
+        if not hasattr(current, attr_name):
+            raise AttributeError(f"No such attribute: {attr_name} in path {path}")
+        old_value = getattr(current, attr_name)
+        return current, attr_name, old_value
 
-        Note:
-            **RECOMMENDED**: Use store.state proxy for type-safe paths with IDE support:
-            `self.pub_redo(str(self.store.state.counter))`
-
-            Redo可能な履歴が存在しない場合は何も実行されません。
-            新しい変更が行われるとRedo履歴はクリアされます。
-        """
-        self.publish(DefaultUndoTopic.REDO, state_path=str(state_path))
-
-    # --- 日本語エイリアス（お好みで使用） ---
-    pub_アンドゥリドゥを有効にする = pub_enable_undo_redo
-    pub_アンドゥリドゥを無効にする = pub_disable_undo_redo
-    pub_戻す = pub_undo
-    pub_進める = pub_redo
-
-    def sub_state_changed(
-        self, state_path: str, handler: Callable[[Any, Any], None]
+    def _validate_and_set_value(
+        self, target_obj: Any, attr_name: str, new_value: Any
     ) -> None:
-        """
-        状態が変更されたときの詳細通知を購読する。
+        """属性値を型検証してから設定する。"""
+        if isinstance(target_obj, BaseModel):
+            model_fields = target_obj.__class__.model_fields
+            if attr_name in model_fields:
+                field_info = model_fields[attr_name]
+                if hasattr(new_value, "model_dump") and hasattr(
+                    field_info.annotation, "model_validate"
+                ):
+                    validated = field_info.annotation.model_validate(new_value)
+                    setattr(target_obj, attr_name, validated)
+                    return
+        setattr(target_obj, attr_name, new_value)
 
-        ハンドラー関数には、old_valueとnew_valueが渡されます。
 
-        Args:
-            state_path (str): 監視する状態のパス（例: "user.name", "items[2].value"）
-            handler (Callable[[Any, Any], None]): 変更時に呼び出される関数。
-                old_valueとnew_valueの2引数を取る
+# グローバルStoreシングルトン
+_store: Optional[Store[Any]] = None
 
-        Note:
-            **RECOMMENDED**: Use store.state proxy for consistent path specification:
-            `self.sub_state_changed(str(self.store.state.user.name), self.on_name_changed)`
-        """
-        self.subscribe(f"{DefaultUpdateTopic.STATE_CHANGED}.{str(state_path)}", handler)
 
-    def sub_for_refresh(self, state_path: str, handler: Callable[[], None]) -> None:
-        """
-        状態が更新されたときにUI再描画用のシンプルな通知を購読する。
-
-        ハンドラー関数は引数なしで呼び出され、ハンドラー内で必要に応じて
-        store.get_current_state()を使用して現在の状態を取得できます。
-
-        Args:
-            state_path (str): 監視する状態のパス（例: "user.name", "items[2].value"）
-            handler (Callable[[], None]): 更新時に呼び出される引数なしの関数
-
-        Note:
-            **RECOMMENDED**: Use store.state proxy for consistent path specification:
-            `self.sub_for_refresh(str(self.store.state.user.name), self.refresh_ui)`
-
-            このメソッドは、変更内容に関係なく「状態が変わったからUI更新」という
-            パターンに最適です。refresh_from_state()と同じロジックを使い回せます。
-        """
-        self.subscribe(f"{DefaultUpdateTopic.STATE_UPDATED}.{str(state_path)}", handler)
-
-    def sub_state_added(
-        self, state_path: str, handler: Callable[[Any, int], None]
-    ) -> None:
-        """
-        リストに要素が追加されたときの通知を購読する。
-
-        ハンドラー関数には、itemとindexが渡されます。
-
-        Args:
-            state_path (str): 監視するリスト状態のパス（例: "items", "user.tasks"）
-            handler (Callable[[Any, int], None]): 要素追加時に呼び出される関数。
-                追加されたアイテムとそのインデックスを引数に取る
-
-        Note:
-            **RECOMMENDED**: Use store.state proxy for consistent path specification:
-            `self.sub_state_added(str(self.store.state.items), self.on_item_added)`
-        """
-        self.subscribe(f"{DefaultUpdateTopic.STATE_ADDED}.{str(state_path)}", handler)
-
-    def sub_dict_item_added(
-        self, state_path: str, handler: Callable[[str, Any], None]
-    ) -> None:
-        """辞書に要素が追加されたときの通知を購読する。
-
-        ハンドラー関数には、キーと値が渡されます。
-
-        Args:
-            state_path: 監視する辞書状態のパス。
-            handler: 追加されたキーと値を引数に取る関数。
-
-        Note:
-            **RECOMMENDED**: Use store.state proxy for consistent path specification:
-            `self.sub_dict_item_added(str(self.store.state.mapping), self.on_added)`
-        """
-        self.subscribe(
-            f"{DefaultUpdateTopic.DICT_ADDED}.{str(state_path)}",
-            handler,
-        )
+def get_store(state_cls: Type[TState]) -> Store[TState]:
+    """グローバルな Store インスタンスを取得します。"""
+    global _store
+    if _store is None:
+        _store = Store(state_cls)
+    else:
+        existing = getattr(_store, "_state_class", None)
+        if existing is not state_cls:
+            raise RuntimeError(
+                f"Store は既に {existing!r} で生成されています（state_cls={state_cls!r}）"
+            )
+    return cast(Store[TState], _store)

--- a/src/pubsubtk/store/store.py
+++ b/src/pubsubtk/store/store.py
@@ -421,6 +421,9 @@ class Store(PubSubBase, Generic[TState]):
                     setattr(target_obj, attr_name, validated_value)
                     return
 
+        # 通常の属性設定
+        setattr(target_obj, attr_name, new_value)
+
 
 # 実体としてはどんな State 型でも格納できるので Any
 _store: Optional[Store[Any]] = None

--- a/src/pubsubtk/store/store.py
+++ b/src/pubsubtk/store/store.py
@@ -34,11 +34,13 @@ class StateProxy(Generic[TState]):
             store: 値を参照する対象 ``Store``。
             path: 現在のパス文字列。
         """
+
         self._store = store
         self._path = path
 
     def __getattr__(self, name: str) -> "StateProxy[TState]":
         """属性アクセスを連結した ``StateProxy`` を返す。"""
+
         new_path = f"{self._path}.{name}" if self._path else name
 
         # 存在チェック：TState モデルに new_path が通るか確認
@@ -53,6 +55,7 @@ class StateProxy(Generic[TState]):
 
     def __repr__(self) -> str:
         """パス文字列を返す。"""
+
         return f"{self._path}"
 
     __str__ = __repr__
@@ -65,7 +68,9 @@ class Store(PubSubBase, Generic[TState]):
     - Pydanticモデルを状態として保持し、状態操作を提供
     - get_current_state()で状態のディープコピーを取得
     - update_state()/add_to_list()/add_to_dict()で状態を更新し、PubSubで通知
-    - Undo/Redo 機能を提供
+    - `store.state.count` のようなパスプロキシを使うことで、
+      `store.update_state(store.state.count, 1)` のようにIDEの「定義へ移動」や補完機能を活用しつつ、
+      状態更新のパスを安全・明示的に指定できる（従来の文字列パス指定の弱点を解消）
     """
 
     def __init__(self, initial_state_class: Type[TState]):
@@ -146,10 +151,10 @@ class Store(PubSubBase, Generic[TState]):
         """
         target_obj, attr_name, old_value = self._resolve_path(str(state_path))
 
-        # Undo履歴をキャプチャ
+        # Undo履歴をキャプチャ（既存の値を記録）
         self._capture_for_undo(str(state_path), old_value)
 
-        # 型チェック後に設定
+        # 新しい値を設定する前に型チェック
         self._validate_and_set_value(target_obj, attr_name, new_value)
 
         # 詳細な変更通知（old_value, new_valueを含む）
@@ -158,41 +163,62 @@ class Store(PubSubBase, Generic[TState]):
             old_value=old_value,
             new_value=new_value,
         )
-        # シンプルな更新通知
+
+        # シンプルな更新通知（引数なし）
         self.publish(f"{DefaultUpdateTopic.STATE_UPDATED}.{state_path}")
 
     def add_to_list(self, state_path: str, item: Any) -> None:
-        """リスト属性に要素を追加し、追加通知を送信する。"""
+        """リスト属性に要素を追加し、追加通知を送信する。
+
+        Args:
+            state_path: 追加先となるリストの属性パス。
+            item: 追加する要素。
+        """
         target_obj, attr_name, current_list = self._resolve_path(str(state_path))
+
         if not isinstance(current_list, list):
             raise TypeError(f"Property at '{state_path}' is not a list")
 
-        # Undo履歴をキャプチャ
+        # Undo履歴をキャプチャ（既存のリストを記録）
         self._capture_for_undo(str(state_path), current_list)
 
+        # リストをコピーして新しい要素を追加
         new_list = current_list.copy()
         new_list.append(item)
+
+        # 新しいリストで更新
         self._validate_and_set_value(target_obj, attr_name, new_list)
 
         index = len(new_list) - 1
+
         self.publish(
             f"{DefaultUpdateTopic.STATE_ADDED}.{state_path}",
             item=item,
             index=index,
         )
+
+        # リスト追加でも更新通知を送信
         self.publish(f"{DefaultUpdateTopic.STATE_UPDATED}.{state_path}")
 
     def add_to_dict(self, state_path: str, key: str, value: Any) -> None:
-        """辞書属性に要素を追加し、追加通知を送信する。"""
+        """辞書属性に要素を追加し、追加通知を送信する。
+
+        Args:
+            state_path: 追加先となる辞書の属性パス。
+            key: 追加するキー。
+            value: 追加する値。
+        """
         target_obj, attr_name, current_dict = self._resolve_path(str(state_path))
+
         if not isinstance(current_dict, dict):
             raise TypeError(f"Property at '{state_path}' is not a dict")
 
-        # Undo履歴をキャプチャ
+        # Undo履歴をキャプチャ（既存の辞書を記録）
         self._capture_for_undo(str(state_path), current_dict)
 
         new_dict = current_dict.copy()
         new_dict[key] = value
+
         self._validate_and_set_value(target_obj, attr_name, new_dict)
 
         self.publish(
@@ -200,103 +226,140 @@ class Store(PubSubBase, Generic[TState]):
             key=key,
             value=value,
         )
+
+        # 辞書追加でも更新通知を送信
         self.publish(f"{DefaultUpdateTopic.STATE_UPDATED}.{state_path}")
 
     # --- Undo/Redo 履歴管理機能 ---
 
     def _enable_undo_redo(self, state_path: str, max_history: int = 10) -> None:
-        """Undo/Redoを有効化し、初回スナップショットとして現在値を記録。"""
+        """指定パスのUndo/Redo機能を有効化し、現在の値を初期スナップショットとして記録する。
+
+        Args:
+            state_path: 追跡対象の状態パス
+            max_history: 保持する履歴の最大数（デフォルト: 10）
+        """
         self._undo_enabled.add(state_path)
         self._max_histories[state_path] = max_history
 
+        # 現在の値を初期スナップショットとして記録
         try:
             _, _, current_value = self._resolve_path(state_path)
             self._undo_stacks[state_path] = [copy.deepcopy(current_value)]
+            self._redo_stacks[state_path].clear()
         except (AttributeError, ValueError):
+            # パスが存在しない場合は空の履歴で開始
             self._undo_stacks[state_path] = []
-        self._redo_stacks[state_path].clear()
+            self._redo_stacks[state_path].clear()
 
-        # UI用ステータス通知
+        # ステータス通知を送信
         self._emit_ur_status(state_path)
 
     def _disable_undo_redo(self, state_path: str) -> None:
-        """Undo/Redoを無効化し、履歴を破棄。"""
+        """指定パスのUndo/Redo機能を無効化し、履歴データを削除する。
+
+        Args:
+            state_path: 無効化する状態パス
+        """
         self._undo_enabled.discard(state_path)
         self._undo_stacks.pop(state_path, None)
         self._redo_stacks.pop(state_path, None)
         self._max_histories.pop(state_path, None)
 
-        # UI用ステータス通知
-        self._emit_ur_status(state_path)
-
     def _capture_for_undo(self, state_path: str, old_value: Any) -> None:
-        """状態変更前に履歴を記録し、Redo履歴をクリア。"""
+        """状態変更前に古い値をUndo履歴に記録する。
+
+        Args:
+            state_path: 変更対象の状態パス
+            old_value: 変更前の値
+        """
+        # Undo/Redo対象でない、またはUndo/Redo操作中の場合はスキップ
         if state_path not in self._undo_enabled or self._during_ur_op:
             return
 
         stack = self._undo_stacks[state_path]
         stack.append(copy.deepcopy(old_value))
 
+        # 履歴上限の管理
         max_len = self._max_histories.get(state_path, 10)
         if len(stack) > max_len:
-            stack.pop(0)
+            stack.pop(0)  # 最古の履歴を削除
 
+        # 新しい変更が発生したのでRedo履歴をクリア
         self._redo_stacks[state_path].clear()
 
-        # UI用ステータス通知
+        # ステータス通知を送信
         self._emit_ur_status(state_path)
 
     def _undo(self, state_path: str) -> None:
-        """1つ前の値に戻す。"""
+        """指定パスの状態を1つ前の値に戻す。
+
+        Args:
+            state_path: Undoを実行する状態パス
+        """
         if state_path not in self._undo_enabled:
             return
+
         undo_stack = self._undo_stacks[state_path]
-        if len(undo_stack) < 2:
+        if len(undo_stack) < 2:  # 現在値 + 少なくとも1つの履歴が必要
             return
 
+        # 現在の値をRedo履歴に保存
         try:
             _, _, current_value = self._resolve_path(state_path)
             self._redo_stacks[state_path].append(copy.deepcopy(current_value))
         except (AttributeError, ValueError):
             return
 
-        self._during_ur_op = True
+        # 最新の履歴値を取得（現在値の1つ前）
+        self._during_ur_op = True  # 再帰防止フラグを設定
         try:
-            undo_stack.pop()
-            prev = undo_stack[-1]
-            self.update_state(state_path, prev)
+            undo_stack.pop()  # 現在値を削除
+            previous_value = undo_stack[-1]  # 1つ前の値を取得（スタックには残す）
+            self.update_state(state_path, previous_value)
         finally:
             self._during_ur_op = False
 
-        # UI用ステータス通知
+        # ステータス通知を送信
         self._emit_ur_status(state_path)
 
     def _redo(self, state_path: str) -> None:
-        """Redo履歴を適用する。"""
+        """指定パスのUndoを取り消し、Redoを実行する。
+
+        Args:
+            state_path: Redoを実行する状態パス
+        """
         if state_path not in self._undo_enabled:
             return
+
         redo_stack = self._redo_stacks[state_path]
         if not redo_stack:
             return
 
+        # 現在の値をUndo履歴に保存
         try:
             _, _, current_value = self._resolve_path(state_path)
             self._undo_stacks[state_path].append(copy.deepcopy(current_value))
         except (AttributeError, ValueError):
             return
 
-        self._during_ur_op = True
+        # Redo値を取得して適用
+        self._during_ur_op = True  # 再帰防止フラグを設定
         try:
-            next_val = redo_stack.pop()
-            self.update_state(state_path, next_val)
+            redo_value = redo_stack.pop()
+            self.update_state(state_path, redo_value)
         finally:
             self._during_ur_op = False
 
-        # UI用ステータス通知
+        # ステータス通知を送信
         self._emit_ur_status(state_path)
 
     def _emit_ur_status(self, state_path: str) -> None:
-        """現在のUndo/Redo可否・スタックサイズを通知する."""
+        """現在のUndo/Redo可否・スタックサイズを通知する。
+
+        Args:
+            state_path: ステータス通知対象の状態パス
+        """
         undo_stack = self._undo_stacks.get(state_path, [])
         redo_stack = self._redo_stacks.get(state_path, [])
         self.publish(
@@ -310,20 +373,31 @@ class Store(PubSubBase, Generic[TState]):
     def _resolve_path(self, path: str) -> tuple[Any, str, Any]:
         """
         属性パスを解決し、対象オブジェクト・属性名・現在値を返す。
+
+        Args:
+            path: 解析する属性パス。
+        Returns:
+            (対象オブジェクト, 属性名, 現在値)
         """
         segments = path.split(".")
+
         if not segments:
             raise ValueError("Empty path")
 
+        # 最後のセグメントを取り出し
         attr_name = segments[-1]
+
+        # 最後のセグメント以外のパスをたどって対象オブジェクトを取得
         current = self._state
         for segment in segments[:-1]:
             if not hasattr(current, segment):
                 raise AttributeError(f"No such attribute: {segment} in path {path}")
             current = getattr(current, segment)
 
+        # 現在の値を取得
         if not hasattr(current, attr_name):
             raise AttributeError(f"No such attribute: {attr_name} in path {path}")
+
         old_value = getattr(current, attr_name)
         return current, attr_name, old_value
 
@@ -331,25 +405,39 @@ class Store(PubSubBase, Generic[TState]):
         self, target_obj: Any, attr_name: str, new_value: Any
     ) -> None:
         """属性値を型検証してから設定する。"""
+        # Pydanticモデルの場合、フィールドの型情報を取得
         if isinstance(target_obj, BaseModel):
             model_fields = target_obj.__class__.model_fields
+
             if attr_name in model_fields:
                 field_info = model_fields[attr_name]
+
+                # もし新しい値がPydanticモデルの場合、model_validateを使用
                 if hasattr(new_value, "model_dump") and hasattr(
                     field_info.annotation, "model_validate"
                 ):
-                    validated = field_info.annotation.model_validate(new_value)
-                    setattr(target_obj, attr_name, validated)
+                    field_type = field_info.annotation
+                    validated_value = field_type.model_validate(new_value)
+                    setattr(target_obj, attr_name, validated_value)
                     return
-        setattr(target_obj, attr_name, new_value)
 
 
-# グローバルStoreシングルトン
+# 実体としてはどんな State 型でも格納できるので Any
 _store: Optional[Store[Any]] = None
 
 
 def get_store(state_cls: Type[TState]) -> Store[TState]:
-    """グローバルな Store インスタンスを取得します。"""
+    """グローバルな ``Store`` インスタンスを取得する。
+
+    Args:
+        state_cls: ``Store`` 生成に使用する状態モデルの型。
+
+    Returns:
+        共有 ``Store`` インスタンス。
+
+    Raises:
+        RuntimeError: 既に別の ``state_cls`` で生成されている場合。
+    """
     global _store
     if _store is None:
         _store = Store(state_cls)
@@ -357,6 +445,6 @@ def get_store(state_cls: Type[TState]) -> Store[TState]:
         existing = getattr(_store, "_state_class", None)
         if existing is not state_cls:
             raise RuntimeError(
-                f"Store は既に {existing!r} で生成されています（state_cls={state_cls!r}）"
+                f"Store は既に {existing!r} で生成されています（呼び出し時の state_cls={state_cls!r}）"
             )
     return cast(Store[TState], _store)

--- a/src/pubsubtk/topic/__init__.py
+++ b/src/pubsubtk/topic/__init__.py
@@ -2,11 +2,11 @@
 
 """PubSub トピック列挙型を公開します。"""
 
-from .topics import AutoNamedTopic, DefaultNavigateTopic, DefaultUpdateTopic
+from .topics import AutoNamedTopic, DefaultNavigateTopic, DefaultUndoTopic, DefaultUpdateTopic
 
 __all__ = [
     "AutoNamedTopic",
     "DefaultNavigateTopic",
+    "DefaultUndoTopic",
     "DefaultUpdateTopic",
 ]
-

--- a/src/pubsubtk/topic/topics.py
+++ b/src/pubsubtk/topic/topics.py
@@ -76,3 +76,4 @@ class DefaultUndoTopic(AutoNamedTopic):
     DISABLE_UNDO_REDO = auto()
     UNDO = auto()
     REDO = auto()
+    STATUS_CHANGED = auto()

--- a/src/pubsubtk/topic/topics.py
+++ b/src/pubsubtk/topic/topics.py
@@ -65,3 +65,14 @@ class DefaultProcessorTopic(AutoNamedTopic):
 
     REGISTER_PROCESSOR = auto()
     DELETE_PROCESSOR = auto()
+
+
+class DefaultUndoTopic(AutoNamedTopic):
+    """
+    Undo/Redo機能用のPubSubトピック列挙型。
+    """
+
+    ENABLE_UNDO_REDO = auto()
+    DISABLE_UNDO_REDO = auto()
+    UNDO = auto()
+    REDO = auto()


### PR DESCRIPTION

## 概要

* Undo/Redo 機能を PubSubTk のコアに共通化実装し、サンプルアプリに適用しました。
* 各状態パス単位で Undo/Redo の有効化・操作・購読が可能となります。

## 目的

* 複数の状態に対して独立して Undo/Redo を提供できるようにし、アプリケーション側での実装負担を大幅に削減することが目的です。

## 主な変更点

* `Store` クラスに Undo/Redo 履歴管理のロジックを追加

  * 任意の state\_path に対し履歴の有効化・無効化、undo/redo 操作をサポート
  * 操作履歴数は個別に上限設定可能
  * Undo/Redo ステータスの PubSub 通知 (`sub_undo_status`) を追加
* コア API (`PubSubDefaultTopicBase`) に Undo/Redo 関連メソッドを追加
* トピック定義 (`DefaultUndoTopic`) の新設
* ドキュメント (`common.md`) へ利用方法・サンプルコードを追記
* サンプルアプリに Undo/Redo UI コントロールを追加し、カウンターや Todo リストで動作することを実証
* テストコード更新

## レビュアー向けポイント

* Undo/Redo 履歴が「状態パス」単位で隔離されており、各 View/Container から独立して制御できます
* Undo/Redo 操作によるステータス更新が PubSub 経由で伝搬され、UI の状態も同期されることを確認してください
* Undo/Redo 実装のための型安全な API 呼び出し例やハンドラー実装は `common.md` のサンプル記載をご参照ください
* サンプルアプリでは

  * 「履歴記録ON/OFF」ボタンで各状態パスごとに履歴管理が有効化/無効化できます
  * Undo/Redo ステータスがリアルタイムに UI 表示されます

## 補足

* 履歴管理の対象や履歴保持数は柔軟に拡張可能です
* ドキュメントの内容やサンプルの分量など、ご指摘・追加要望があればご連絡ください

